### PR TITLE
Update Scheduler.php

### DIFF
--- a/src/Readdle/Scheduler.php
+++ b/src/Readdle/Scheduler.php
@@ -69,6 +69,7 @@ class Scheduler
                 $nextRun = (int)$this->dataStorage->get($scriptName);
 
                 if ($nextRun > time()) {
+                    $this->updateNextRun($nextRun);
                     continue;
                 }
 
@@ -81,7 +82,7 @@ class Scheduler
                 $this->dataStorage->save($scriptName, $nextRun);
             }
 
-            if ($this->nextRun > time()) {
+            if ($this->nextRun > time() + 1) { //to avoid proble with time_sleep_until 
                 time_sleep_until($this->nextRun);
             }
             $this->nextRun = null;


### PR DESCRIPTION
Fixed problems:
 - on first run scheduler doesn't update `$this->nextRun` and didn't sleep
 - when nextRun is greater than time() only for 1 sec, `time_sleep_until` function can throw error, that time is already equal to nextRun